### PR TITLE
Disallow zoom and rotate at the same time in RotationControls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potree",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "WebGL point cloud viewer",
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/src/navigation/RotationControls.js
+++ b/src/navigation/RotationControls.js
@@ -55,6 +55,7 @@ Potree.RotationControls = class RotationControls extends THREE.EventDispatcher{
 
 			if (e.drag.mouse === Potree.MOUSE.LEFT) {
 				this.yawDelta += ndrag.x * this.rotationSpeed;
+				this.radiusDelta = 0;
 
 				this.navigationCallback();
 
@@ -70,6 +71,7 @@ Potree.RotationControls = class RotationControls extends THREE.EventDispatcher{
 			let resolvedRadius = this.scene.view.radius + this.radiusDelta;
 
 			this.radiusDelta += -e.delta * resolvedRadius * 0.1;
+			this.yawDelta = 0;
 
 			this.navigationCallback();
 
@@ -149,6 +151,15 @@ Potree.RotationControls = class RotationControls extends THREE.EventDispatcher{
 			return false;
 		}
 
+		const fixedRadiusDelta = Math.floor(this.radiusDelta * 1000) / 1000;
+		const fixedYawDelta = Math.floor(this.yawDelta * 1000) / 1000;
+		if (fixedRadiusDelta !== 0) {
+			this.yawDelta = 0;
+		} else
+		if (fixedYawDelta !== 0) {
+			this.radiusDelta = 0;
+		}
+
 		{ // apply rotation
 			let progression = Math.min(1, this.fadeFactor * delta);
 
@@ -156,7 +167,6 @@ Potree.RotationControls = class RotationControls extends THREE.EventDispatcher{
 			let pivot = view.getPivot();
 
 			yaw -= progression * this.yawDelta;
-
 
 			if (yaw < -Math.PI && this.yawDelta > 0) {
 				yaw = Math.PI;

--- a/src/navigation/RotationControls.js
+++ b/src/navigation/RotationControls.js
@@ -151,8 +151,8 @@ Potree.RotationControls = class RotationControls extends THREE.EventDispatcher{
 			return false;
 		}
 
-		const fixedRadiusDelta = Math.floor(this.radiusDelta * 1000) / 1000;
-		const fixedYawDelta = Math.floor(this.yawDelta * 1000) / 1000;
+		const fixedRadiusDelta = +(this.radiusDelta).toFixed(3);
+		const fixedYawDelta = +(this.yawDelta).toFixed(3);
 		if (fixedRadiusDelta !== 0) {
 			this.yawDelta = 0;
 		} else


### PR DESCRIPTION
It's easier to manage sync between crop sliders and crop area in Point Cloud Extractor app if we don't rotate or zoom the view at the same time. This can happen when you rotate and then quickly zoom the view - both zoom and rotation speed is fading out over time. It's a problem because while we use zoom feature, we need to update crop sliders according to the crop area but at the same time, the crop area's anchor points are being rotated along with the view.