### PR TITLE
Do not load points that are not part of clip boxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potree",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "WebGL point cloud viewer",
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/src/Potree.js
+++ b/src/Potree.js
@@ -609,8 +609,10 @@ Potree.updateVisibility = function(pointclouds, camera, renderer){
 			let insideAny = numIntersecting > 0;
 			let insideAll = numIntersecting === numIntersectionVolumes;
 
+			// There are other clip tasks but we are not using them (highlight and show_outside).
 			if(pointcloud.material.clipTask === Potree.ClipTask.SHOW_INSIDE) {
 				if (
+					// Check if the node is outside the crop plane and turn off visibility for them
 					!(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ANY && insideAny) &&
 					!(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ALL && insideAll)
 				) {

--- a/src/Potree.js
+++ b/src/Potree.js
@@ -566,17 +566,13 @@ Potree.updateVisibility = function(pointclouds, camera, renderer){
 			// TODO
 			window.warned125 = true;
 		}
-		if(false && pointcloud.material.clipBoxes.length > 0){
 
-			
-
-			//node.debug = false;
-
+		if(pointcloud.material.clipBoxes.length > 0) {
 			let numIntersecting = 0;
 			let numIntersectionVolumes = 0;
 
+			// Loop through clip boxes and look for intersections with current node
 			for(let clipBox of pointcloud.material.clipBoxes){
-
 				let pcWorldInverse = new THREE.Matrix4().getInverse(pointcloud.matrixWorld);
 				let toPCObject = pcWorldInverse.multiply(clipBox.box.matrixWorld);
 
@@ -613,21 +609,15 @@ Potree.updateVisibility = function(pointclouds, camera, renderer){
 			let insideAny = numIntersecting > 0;
 			let insideAll = numIntersecting === numIntersectionVolumes;
 
-			if(pointcloud.material.clipTask === Potree.ClipTask.SHOW_INSIDE){
-				if(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ANY && insideAny){
-					//node.debug = true
-				}else if(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ALL && insideAll){
-					//node.debug = true;
-				}else{
+			if(pointcloud.material.clipTask === Potree.ClipTask.SHOW_INSIDE) {
+				if (
+					!(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ANY && insideAny) &&
+					!(pointcloud.material.clipMethod === Potree.ClipMethod.INSIDE_ALL && insideAll)
+				) {
 					visible = false;
 				}
 			}
-			
-
 		}
-
-		// visible = ["r", "r0", "r06", "r060"].includes(node.name);
-		// visible = ["r"].includes(node.name);
 
 		if (node.spacing) {
 			lowestSpacing = Math.min(lowestSpacing, node.spacing);


### PR DESCRIPTION
So, previously, when point clouds were cropped (e.g. asset view), all points were loaded in the memory - even those that were not visible. This should help with this particular problem.