### PR TITLE
Include ExtractorControls in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,7 @@ let paths = {
 		"src/navigation/FirstPersonControls.js",
 		"src/navigation/GeoControls.js",
 		"src/navigation/OrbitControls.js",
+		"src/navigation/ExtractorControls.js",
 		"src/navigation/EarthControls.js",
 		"src/LRU.js",
 		"src/Annotation.js",


### PR DESCRIPTION
I forgot to include ExtractorControls in gulp build 🤦🏻‍♂️
It's required to include it in the build version.